### PR TITLE
feat:상품 도메인 ES적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation group: 'org.springframework.batch', name: 'spring-batch-integration', version: '5.0.1'
     implementation 'org.projectlombok:lombok:1.18.20'
+	implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/OptimisticLockQuantityFacade.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/OptimisticLockQuantityFacade.java
@@ -1,4 +1,4 @@
-package com.unicornstudy.singleshop.items.application;
+package com.unicornstudy.singleshop.items.command.application;
 
 import com.unicornstudy.singleshop.exception.ErrorCode;
 import com.unicornstudy.singleshop.exception.items.ItemsException;

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsRequestDto.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsRequestDto.java
@@ -1,10 +1,9 @@
-package com.unicornstudy.singleshop.items.application.dto;
+package com.unicornstudy.singleshop.items.command.application.dto;
 
+import com.unicornstudy.singleshop.items.domain.ChildCategory;
 import com.unicornstudy.singleshop.items.domain.Items;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.unicornstudy.singleshop.items.domain.ParentCategory;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -18,6 +17,8 @@ public class ItemsRequestDto {
     private Integer price;
     private String description;
     private Integer quantity;
+    private String parentCategory;
+    private String childCategory;
 
     public Items toEntity() {
         return Items.builder()
@@ -26,6 +27,9 @@ public class ItemsRequestDto {
                 .description(getDescription())
                 .quantity(getQuantity())
                 .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
+                .parentCategory(ParentCategory.valueOf(getParentCategory()))
+                .childCategory(ChildCategory.valueOf(getChildCategory()))
                 .build();
     }
 

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsResponseDto.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsResponseDto.java
@@ -1,4 +1,4 @@
-package com.unicornstudy.singleshop.items.application.dto;
+package com.unicornstudy.singleshop.items.command.application.dto;
 
 import com.unicornstudy.singleshop.items.domain.Items;
 import lombok.Builder;

--- a/src/main/java/com/unicornstudy/singleshop/items/command/presentation/ItemsController.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/presentation/ItemsController.java
@@ -1,17 +1,12 @@
-package com.unicornstudy.singleshop.items.presentation;
+package com.unicornstudy.singleshop.items.command.presentation;
 
-import com.unicornstudy.singleshop.items.application.ItemsService;
-import com.unicornstudy.singleshop.items.application.dto.ItemsRequestDto;
-import com.unicornstudy.singleshop.items.application.dto.ItemsResponseDto;
+import com.unicornstudy.singleshop.items.command.application.ItemsService;
+import com.unicornstudy.singleshop.items.command.application.dto.ItemsRequestDto;
+import com.unicornstudy.singleshop.items.command.application.dto.ItemsResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,16 +14,6 @@ import java.util.List;
 public class ItemsController {
 
     private final ItemsService itemService;
-
-    @GetMapping("/{id}")
-    public ResponseEntity<ItemsResponseDto> findById(@PathVariable Long id) {
-        return new ResponseEntity<>(itemService.findById(id), HttpStatus.OK);
-    }
-
-    @GetMapping
-    public ResponseEntity<List<ItemsResponseDto>> findByAll(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return new ResponseEntity<>(itemService.findAll(pageable), HttpStatus.OK);
-    }
 
     @PostMapping
     public ResponseEntity<ItemsResponseDto> save(@RequestBody ItemsRequestDto requestDto) {

--- a/src/main/java/com/unicornstudy/singleshop/items/domain/ChildCategory.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/domain/ChildCategory.java
@@ -1,0 +1,5 @@
+package com.unicornstudy.singleshop.items.domain;
+
+public enum ChildCategory {
+    KIMCHI, SALAD, FRIED, SEAFOOD, MEAT, VEGETABLES
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/domain/Items.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/domain/Items.java
@@ -36,13 +36,21 @@ public class Items {
 
     private LocalDateTime createdDate;
 
-    public void update(Long id, String name, Integer price, String description, Integer quantity) {
+    @Enumerated(EnumType.STRING)
+    private ParentCategory parentCategory;
+
+    @Enumerated(EnumType.STRING)
+    private ChildCategory childCategory;
+
+    public void update(Long id, String name, Integer price, String description, Integer quantity, ParentCategory parentCategory, ChildCategory childCategory) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.description = description;
         this.quantity = quantity;
         this.modifiedDate = LocalDateTime.now();
+        this.parentCategory = parentCategory;
+        this.childCategory = childCategory;
     }
 
     public void increaseQuantity() {

--- a/src/main/java/com/unicornstudy/singleshop/items/domain/ParentCategory.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/domain/ParentCategory.java
@@ -1,0 +1,5 @@
+package com.unicornstudy.singleshop.items.domain;
+
+public enum ParentCategory {
+    FOOD
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/application/ItemsSearchService.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/application/ItemsSearchService.java
@@ -1,0 +1,30 @@
+package com.unicornstudy.singleshop.items.query.application;
+
+import com.unicornstudy.singleshop.items.query.application.dto.ItemsSearchDto;
+import com.unicornstudy.singleshop.items.query.domain.repository.ItemsSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemsSearchService {
+
+    private final ItemsSearchRepository itemsSearchRepository;
+
+    public List<ItemsSearchDto> findAll(Pageable pageable) {
+        return itemsSearchRepository.findAll(pageable)
+                .stream()
+                .map(items -> ItemsSearchDto.from(items))
+                .toList();
+    }
+
+    public List<ItemsSearchDto> findItems(String name, int price1, int price2, String parentCategory, String childCategory, Pageable pageable) {
+        return itemsSearchRepository.findItems(name, price1, price2, parentCategory, childCategory, pageable)
+                .stream()
+                .map(items -> ItemsSearchDto.from(items))
+                .toList();
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/application/dto/ItemsSearchDto.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/application/dto/ItemsSearchDto.java
@@ -1,0 +1,45 @@
+package com.unicornstudy.singleshop.items.query.application.dto;
+
+import com.unicornstudy.singleshop.items.query.domain.ItemsIndex;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ItemsSearchDto {
+    private final Long id;
+    private final String name;
+    private final Integer price;
+    private final String description;
+    private final Integer quantity;
+    private final String createdDate;
+    private final String modifiedDate;
+    private final String parentCategory;
+    private final String childCategory;
+
+    @Builder
+    public ItemsSearchDto(Long id, String name, int price, String description, int quantity, String createdDate, String modifiedDate, String parentCategory, String childCategory) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.description = description;
+        this.quantity = quantity;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+        this.parentCategory = parentCategory;
+        this.childCategory = childCategory;
+    }
+
+    public static ItemsSearchDto from(ItemsIndex itemsIndex) {
+        return ItemsSearchDto.builder()
+                .id(itemsIndex.getId())
+                .name(itemsIndex.getName())
+                .description(itemsIndex.getDescription())
+                .price(itemsIndex.getPrice())
+                .quantity(itemsIndex.getQuantity())
+                .createdDate(itemsIndex.getCreatedDate())
+                .modifiedDate(itemsIndex.getModifiedDate())
+                .parentCategory(itemsIndex.getParentCategory().name())
+                .childCategory(itemsIndex.getChildCategory().name())
+                .build();
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/domain/ItemsIndex.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/domain/ItemsIndex.java
@@ -1,0 +1,63 @@
+package com.unicornstudy.singleshop.items.query.domain;
+
+import com.unicornstudy.singleshop.items.domain.ChildCategory;
+import com.unicornstudy.singleshop.items.domain.Items;
+import com.unicornstudy.singleshop.items.domain.ParentCategory;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "items")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ItemsIndex {
+
+    @Id
+    @Field(type = FieldType.Long)
+    private Long id;
+
+    @Field(type = FieldType.Keyword)
+    private String name;
+
+    @Field(type = FieldType.Integer)
+    private Integer price;
+
+    @Field(type = FieldType.Keyword)
+    private String description;
+
+    @Field(type = FieldType.Integer)
+    private Integer quantity;
+
+    @Field(type = FieldType.Date)
+    private String modifiedDate;
+
+    @Field(type = FieldType.Date)
+    private String createdDate;
+
+    @Field(type = FieldType.Keyword)
+    private ParentCategory parentCategory;
+
+    @Field(type = FieldType.Keyword)
+    private ChildCategory childCategory;
+
+    public static ItemsIndex createElasticSearchItems(Items items) {
+        return ItemsIndex.builder()
+                .id(items.getId())
+                .name(items.getName())
+                .price(items.getPrice())
+                .description(items.getDescription())
+                .quantity(items.getQuantity())
+                .modifiedDate(items.getModifiedDate().toString())
+                .createdDate(items.getCreatedDate().toString())
+                .parentCategory(items.getParentCategory())
+                .childCategory(items.getChildCategory())
+                .build();
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/ItemsSearchRepository.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/ItemsSearchRepository.java
@@ -1,0 +1,18 @@
+package com.unicornstudy.singleshop.items.query.domain.repository;
+
+import com.unicornstudy.singleshop.items.query.domain.ItemsIndex;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface ItemsSearchRepository extends ElasticsearchRepository<ItemsIndex, Long>, CrudRepository<ItemsIndex, Long> {
+
+    @Query("{\"bool\": {\"must\": [{\"bool\": {\"should\": [{\"wildcard\": {\"name\":\"*?0*\"}},{\"wildcard\": {\"description\": \"*?0*\"}}]}}," +
+            "{\"range\": {\"price\": {\"gte\": ?1,\"lte\": ?2}}}," +
+            "{\"wildcard\": {\"parentCategory\": \"*?3*\"}}," +
+            "{\"wildcard\": {\"childCategory\": \"*?4*\"}}]}}")
+    List<ItemsIndex> findItems(String name, Integer price1, Integer price2, String parentCategory, String childCategory, Pageable pageable);
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/infrastructure/ElasticsearchConfig.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/infrastructure/ElasticsearchConfig.java
@@ -1,0 +1,26 @@
+package com.unicornstudy.singleshop.items.query.infrastructure;
+
+import com.unicornstudy.singleshop.items.query.domain.repository.ItemsSearchRepository;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackageClasses = {ItemsSearchRepository.class})
+public class ElasticsearchConfig extends AbstractElasticsearchConfiguration {
+
+    @Value("${elasticsearch-hostAndPort}")
+    String elasticsearchHostAndPort;
+
+    @Override
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+                .connectedTo(elasticsearchHostAndPort)
+                .build();
+        return RestClients.create(clientConfiguration).rest();
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/presentation/ItemsSearchController.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/presentation/ItemsSearchController.java
@@ -1,0 +1,39 @@
+package com.unicornstudy.singleshop.items.query.presentation;
+
+import com.unicornstudy.singleshop.items.query.application.ItemsSearchService;
+import com.unicornstudy.singleshop.items.query.application.dto.ItemsSearchDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/items")
+public class ItemsSearchController {
+
+    private final ItemsSearchService itemsSearchService;
+
+    @GetMapping("/{name}")
+    public ResponseEntity<List<ItemsSearchDto>> findById(@PathVariable String name,
+                                                         @RequestParam(value = "price1", defaultValue = "0") int price1,
+                                                         @RequestParam(value= "price2", defaultValue = "2147483647") int price2,
+                                                         @RequestParam(value = "parentCategory", defaultValue = "") String parentCategory,
+                                                         @RequestParam(value = "childCategory", defaultValue = "") String childCategory,
+                                                         @PageableDefault(size=10, sort="createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        System.out.println(price1);
+        return new ResponseEntity<>(itemsSearchService.findItems(name, price1, price2, parentCategory, childCategory, pageable), HttpStatus.OK);
+
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ItemsSearchDto>> findAll(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return new ResponseEntity<>(itemsSearchService.findAll(pageable), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/unicornstudy/singleshop/orders/application/OrderService.java
+++ b/src/main/java/com/unicornstudy/singleshop/orders/application/OrderService.java
@@ -7,7 +7,7 @@ import com.unicornstudy.singleshop.exception.carts.CartNotFoundException;
 import com.unicornstudy.singleshop.exception.carts.SessionExpiredException;
 import com.unicornstudy.singleshop.delivery.domain.Delivery;
 import com.unicornstudy.singleshop.items.domain.Items;
-import com.unicornstudy.singleshop.items.application.OptimisticLockQuantityFacade;
+import com.unicornstudy.singleshop.items.command.application.OptimisticLockQuantityFacade;
 import com.unicornstudy.singleshop.orders.domain.OrderStatus;
 import com.unicornstudy.singleshop.payments.domain.Payment;
 import com.unicornstudy.singleshop.orders.application.dto.OrderDetailDto;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,3 +7,4 @@ domain: http://localhost:8080
 subscription-approve-url: http://localhost:8080/api/payments/kakaopay/subscription/approve
 subscription-cancel-url: http://localhost:8080/api/payments/kakaopay/subscription/cancel
 subscription-fail-url: http://localhost:8080/api/payments/kakaopay/subscription/fail
+elasticsearch-hostAndPort: localhost:9200

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,11 @@ spring:
     property-naming-strategy: SNAKE_CASE
 admin-key: "${kakaoAdminKey}"
 kakao-base-url: https://kapi.kakao.com/v1/payment
+logging:
+  level:
+    org:
+      springframework:
+        data:
+          elasticsearch:
+            client:
+              WIRE: TRACE

--- a/src/test/java/com/unicornstudy/singleshop/config/TestSetting.java
+++ b/src/test/java/com/unicornstudy/singleshop/config/TestSetting.java
@@ -4,7 +4,9 @@ import com.unicornstudy.singleshop.carts.domain.Cart;
 import com.unicornstudy.singleshop.carts.domain.CartItem;
 import com.unicornstudy.singleshop.delivery.domain.Address;
 import com.unicornstudy.singleshop.delivery.domain.Delivery;
+import com.unicornstudy.singleshop.items.domain.ChildCategory;
 import com.unicornstudy.singleshop.items.domain.Items;
+import com.unicornstudy.singleshop.items.domain.ParentCategory;
 import com.unicornstudy.singleshop.orders.domain.OrderItem;
 import com.unicornstudy.singleshop.orders.domain.Orders;
 import com.unicornstudy.singleshop.payments.domain.Payment;
@@ -15,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +30,10 @@ public class TestSetting {
                 .price(10)
                 .description("description")
                 .quantity(1)
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
+                .childCategory(ChildCategory.KIMCHI)
+                .parentCategory(ParentCategory.FOOD)
                 .build();
     }
 

--- a/src/test/java/com/unicornstudy/singleshop/items/ItemsControllerTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/items/ItemsControllerTest.java
@@ -2,8 +2,8 @@ package com.unicornstudy.singleshop.items;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.unicornstudy.singleshop.config.TestSetting;
-import com.unicornstudy.singleshop.items.application.ItemsService;
-import com.unicornstudy.singleshop.items.application.dto.ItemsRequestDto;
+import com.unicornstudy.singleshop.items.command.application.ItemsService;
+import com.unicornstudy.singleshop.items.command.application.dto.ItemsRequestDto;
 import com.unicornstudy.singleshop.items.domain.repository.ItemsRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,9 +14,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;

--- a/src/test/java/com/unicornstudy/singleshop/items/ItemsRepositoryTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/items/ItemsRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.unicornstudy.singleshop.items;
 
+import com.unicornstudy.singleshop.items.domain.ChildCategory;
 import com.unicornstudy.singleshop.items.domain.Items;
+import com.unicornstudy.singleshop.items.domain.ParentCategory;
 import com.unicornstudy.singleshop.items.domain.repository.ItemsRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -125,8 +127,11 @@ class ItemsRepositoryTest {
         String updateDescription = "설명";
         Integer updateQuantity = 5;
         LocalDateTime now = LocalDateTime.now();
+        ParentCategory parentCategory = ParentCategory.FOOD;
+        ChildCategory childCategory = ChildCategory.KIMCHI;
 
-        items.update(items.getId(), updateName, updatePrice, updateDescription, updateQuantity);
+
+        items.update(items.getId(), updateName, updatePrice, updateDescription, updateQuantity, parentCategory, childCategory);
 
         assertThat(items.getName()).isEqualTo(updateName);
         assertThat(items.getPrice()).isEqualTo(updatePrice);

--- a/src/test/java/com/unicornstudy/singleshop/items/ItemsServiceTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/items/ItemsServiceTest.java
@@ -1,7 +1,7 @@
 package com.unicornstudy.singleshop.items;
 
-import com.unicornstudy.singleshop.items.application.ItemsService;
-import com.unicornstudy.singleshop.items.application.dto.ItemsRequestDto;
+import com.unicornstudy.singleshop.items.command.application.ItemsService;
+import com.unicornstudy.singleshop.items.command.application.dto.ItemsRequestDto;
 import com.unicornstudy.singleshop.items.domain.repository.ItemsRepository;
 import com.unicornstudy.singleshop.exception.items.ItemsException;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/unicornstudy/singleshop/items/OptimisticLockQuantityFacadeTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/items/OptimisticLockQuantityFacadeTest.java
@@ -1,6 +1,6 @@
 package com.unicornstudy.singleshop.items;
 
-import com.unicornstudy.singleshop.items.application.OptimisticLockQuantityFacade;
+import com.unicornstudy.singleshop.items.command.application.OptimisticLockQuantityFacade;
 import com.unicornstudy.singleshop.items.domain.Items;
 import com.unicornstudy.singleshop.items.domain.repository.ItemsRepository;
 import com.unicornstudy.singleshop.exception.items.ItemsException;

--- a/src/test/java/com/unicornstudy/singleshop/items/query/ItemsSearchControllerTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/items/query/ItemsSearchControllerTest.java
@@ -1,0 +1,102 @@
+package com.unicornstudy.singleshop.items.query;
+
+import com.unicornstudy.singleshop.config.TestSetting;
+import com.unicornstudy.singleshop.items.domain.Items;
+import com.unicornstudy.singleshop.items.query.application.ItemsSearchService;
+import com.unicornstudy.singleshop.items.query.application.dto.ItemsSearchDto;
+import com.unicornstudy.singleshop.items.query.domain.ItemsIndex;
+import com.unicornstudy.singleshop.items.query.presentation.ItemsSearchController;
+import com.unicornstudy.singleshop.orders.application.OrderService;
+import com.unicornstudy.singleshop.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(ItemsSearchController.class)
+@WithMockUser(roles = "USER")
+public class ItemsSearchControllerTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ItemsSearchService itemsSearchService;
+
+    @MockBean
+    private OrderService orderService;
+
+    private MockHttpSession session = new MockHttpSession();
+
+    private User user;
+
+    private Items items;
+
+    private Pageable pageable;
+
+    private List<ItemsSearchDto> expected = new ArrayList<>();
+
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+        user = TestSetting.setUser(TestSetting.setAddress());
+        items = TestSetting.setItem();
+        pageable = TestSetting.setPageable();
+        expected.add(ItemsSearchDto.from(ItemsIndex.createElasticSearchItems(items)));
+    }
+
+    @Test
+    @DisplayName("전체 상품 조회 테스트")
+    void 전체_상품_조회_테스트() throws Exception {
+        when(itemsSearchService.findAll(any(Pageable.class))).thenReturn(expected);
+
+        mockMvc
+                .perform(get("/api/items").session(session)
+                        .characterEncoding("utf-8"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.*", hasSize(expected.size())));
+
+    }
+
+    @Test
+    @DisplayName("상품 명, 내용, 가격 조회 테스트")
+    void 복합_쿼리_테스트() throws Exception {
+        when(itemsSearchService.findItems(any(String.class), any(Integer.class),
+                any(Integer.class), any(String.class), any(String.class), any(Pageable.class))).thenReturn(expected);
+
+        mockMvc
+                .perform(get("/api/items/test").session(session)
+                        .characterEncoding("utf-8"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.*", hasSize(expected.size())));
+    }
+}

--- a/src/test/java/com/unicornstudy/singleshop/items/query/ItemsSearchServiceTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/items/query/ItemsSearchServiceTest.java
@@ -1,0 +1,70 @@
+package com.unicornstudy.singleshop.items.query;
+
+import com.unicornstudy.singleshop.config.TestSetting;
+import com.unicornstudy.singleshop.items.query.application.ItemsSearchService;
+import com.unicornstudy.singleshop.items.query.application.dto.ItemsSearchDto;
+import com.unicornstudy.singleshop.items.query.domain.ItemsIndex;
+import com.unicornstudy.singleshop.items.query.domain.repository.ItemsSearchRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class ItemsSearchServiceTest {
+
+    @Mock
+    private ItemsSearchRepository itemsSearchRepository;
+
+    private ItemsSearchService itemsSearchService;
+
+    private Pageable pageable;
+
+    private ItemsIndex item;
+
+    private List<ItemsIndex> itemsList;
+
+    private Page<ItemsIndex> expected;
+
+    @BeforeEach
+    void setUp() {
+        itemsSearchService = new ItemsSearchService(itemsSearchRepository);
+        pageable = TestSetting.setPageable();
+        item = ItemsIndex.createElasticSearchItems(TestSetting.setItem());
+        itemsList = Arrays.asList(item);
+        expected = new PageImpl<>(itemsList, pageable, itemsList.size());
+    }
+
+    @Test
+    @DisplayName("모든 상품 검색 테스트")
+    void 모든_상품_검색_테스트() {
+        when(itemsSearchRepository.findAll(any(Pageable.class))).thenReturn(expected);
+
+        List<ItemsSearchDto> result = itemsSearchService.findAll(pageable);
+
+        List<ItemsSearchDto> expectedDtoList = expected.stream().map(ItemsSearchDto::from).toList();
+        assertThat(result.get(0).getId()).isEqualTo(expectedDtoList.get(0).getId());
+    }
+
+    @Test
+    @DisplayName("상품 명, 내용, 가격 조회 테스트")
+    void 복합_쿼리_테스트() {
+        when(itemsSearchRepository.findItems(item.getName(), item.getPrice(), item.getPrice(), item.getParentCategory().name(), item.getChildCategory().name(), pageable))
+                .thenReturn(itemsList);
+        List<ItemsSearchDto> result = itemsSearchService.findItems(item.getName(), item.getPrice(), item.getPrice(), item.getParentCategory().name(), item.getChildCategory().name(), pageable);
+        List<ItemsSearchDto> expectedDtoList = expected.stream().map(ItemsSearchDto::from).toList();
+        assertThat(result.get(0).getId()).isEqualTo(expectedDtoList.get(0).getId());
+    }
+}

--- a/src/test/java/com/unicornstudy/singleshop/orders/OrderServiceTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/orders/OrderServiceTest.java
@@ -10,7 +10,7 @@ import com.unicornstudy.singleshop.delivery.domain.Delivery;
 import com.unicornstudy.singleshop.delivery.domain.DeliveryStatus;
 import com.unicornstudy.singleshop.exception.orders.*;
 import com.unicornstudy.singleshop.items.domain.Items;
-import com.unicornstudy.singleshop.items.application.OptimisticLockQuantityFacade;
+import com.unicornstudy.singleshop.items.command.application.OptimisticLockQuantityFacade;
 import com.unicornstudy.singleshop.orders.application.OrderService;
 import com.unicornstudy.singleshop.orders.application.dto.OrderDto;
 import com.unicornstudy.singleshop.orders.domain.*;


### PR DESCRIPTION
상품 도메인 카테고리 기능 추가 -> 상위 카테고리, 하위 카테고리 enum타입으로 생성, 상품 생성, 변경 요청시 dto에 카테고리도 입력 받을 수 있도록 변경

상품 도메인 엘라스틱 서치 추가 -> 상품 이름, 카테고리, 가격으로 검색 가능하도록 쿼리 생성

엘라스틱 서치 단위 테스트 -> 컨트롤러 메소드 2개, 서비스 메소드 2개 단위테스트