### PR TITLE
feat: elasticsearch 저장 방식 메세지 큐를 이용한 이벤트 기반으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation group: 'org.springframework.batch', name: 'spring-batch-integration', version: '5.0.1'
     implementation 'org.projectlombok:lombok:1.18.20'
 	implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -42,6 +44,7 @@ dependencies {
 
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/unicornstudy/singleshop/common/infrastructure/kafka/kafkaConfig.java
+++ b/src/main/java/com/unicornstudy/singleshop/common/infrastructure/kafka/kafkaConfig.java
@@ -1,0 +1,38 @@
+package com.unicornstudy.singleshop.common.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@RequiredArgsConstructor
+public class kafkaConfig {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    private final long INTERVAL_TIME = 1L;
+
+    private final long MAX_ATTEMPTS = 3L;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> multiTypeKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setCommonErrorHandler(errorHandler());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+        factory.afterPropertiesSet();
+        return factory;
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler() {
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+                new DeadLetterPublishingRecoverer(kafkaTemplate), new FixedBackOff(INTERVAL_TIME, MAX_ATTEMPTS));
+        return errorHandler;
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/ItemsService.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/ItemsService.java
@@ -23,12 +23,10 @@ import static com.unicornstudy.singleshop.exception.ErrorCode.*;
 public class ItemsService {
 
     private final ItemsRepository itemsRepository;
-    private final ItemsSearchRepository itemsSearchRepository;
 
     @Transactional(readOnly = true)
     public ItemsResponseDto findById(Long id) {
         Items items = itemsRepository.findById(id).orElseThrow(() -> new ItemsException(BAD_REQUEST_ITEMS_READ));
-
         return ItemsResponseDto.from(items);
     }
 
@@ -42,7 +40,6 @@ public class ItemsService {
     @Transactional
     public ItemsResponseDto save(ItemsRequestDto requestDto) {
         Items items = itemsRepository.save(requestDto.toEntity());
-        itemsSearchRepository.save(ItemsIndex.createElasticSearchItems(items));
         return ItemsResponseDto.from(items);
     }
 
@@ -53,7 +50,6 @@ public class ItemsService {
         items.update(id, requestDto.getName(), requestDto.getPrice(),
                 requestDto.getDescription(), requestDto.getQuantity(),
                 ParentCategory.valueOf(requestDto.getParentCategory()), ChildCategory.valueOf(requestDto.getChildCategory()));
-        itemsSearchRepository.save(ItemsIndex.createElasticSearchItems(items));
         return ItemsResponseDto.from(items);
     }
 
@@ -61,21 +57,20 @@ public class ItemsService {
     public Long delete(Long id) {
         Items items = itemsRepository.findById(id).orElseThrow(() -> new ItemsException(BAD_REQUEST_ITEMS_READ));
         itemsRepository.delete(items);
-        itemsSearchRepository.deleteById(items.getId());
         return id;
     }
 
     @Transactional
-    public void subtractQuantity(Long id) {
+    public ItemsResponseDto subtractQuantity(Long id) {
         Items item = itemsRepository.findById(id).orElseThrow(() -> new ItemsException(BAD_REQUEST_ITEMS_READ));
         item.decreaseQuantity();
-        itemsSearchRepository.save(ItemsIndex.createElasticSearchItems(item));
+        return ItemsResponseDto.from(item);
     }
 
     @Transactional
-    public void addQuantity(Long id) {
+    public ItemsResponseDto addQuantity(Long id) {
         Items item = itemsRepository.findById(id).orElseThrow(() -> new ItemsException(BAD_REQUEST_ITEMS_READ));
         item.increaseQuantity();
-        itemsSearchRepository.save(ItemsIndex.createElasticSearchItems(item));
+        return ItemsResponseDto.from(item);
     }
 }

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/aop/ItemsAspect.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/aop/ItemsAspect.java
@@ -1,0 +1,50 @@
+package com.unicornstudy.singleshop.items.command.application.aop;
+
+import com.unicornstudy.singleshop.items.command.application.dto.ItemsResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ItemsAspect {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @AfterReturning(pointcut = "execution(* com.unicornstudy.singleshop.items.command.application.ItemsService.save(..)) " +
+            "|| execution(* com.unicornstudy.singleshop.items.command.application.ItemsService.update(..))" +
+            "|| execution(* com.unicornstudy.singleshop.items.command.application.ItemsService.subtractQuantity(..))" +
+            "|| execution(* com.unicornstudy.singleshop.items.command.application.ItemsService.addQuantity(..))"
+            , returning = "itemsResponseDto")
+    public void sendToCreateAndUpdateMessageQueue(ItemsResponseDto itemsResponseDto) {
+        log.info("ItemsService 저장 성공, 메시지큐에 메시지 전송");
+        sendToMessageQueue("ItemsCreateAndUpdateTopic", "CreateAndUpdateDLQ", itemsResponseDto);
+    }
+
+    @AfterReturning(pointcut = "execution(* com.unicornstudy.singleshop.items.command.application.ItemsService.delete(..))", returning = "id")
+    public void sendToDeleteMessageQueue(Long id) {
+        log.info("ItemsService 삭제 성공, 메시지큐에 메시지 전송");
+        sendToMessageQueue("ItemsDeleteTopic", "DeleteDLQ", id);
+    }
+
+    private void sendToMessageQueue(String topic, String dlq, Object payload) {
+        CompletableFuture<SendResult<String, Object>> future = kafkaTemplate.send(topic, payload);
+
+        future.whenComplete((result, exception) -> {
+            if (exception != null) {
+                log.error("메시지 전달 실패 Dead Letter Queue에 메시지 전송");
+                kafkaTemplate.send(dlq, payload);
+            } else {
+                log.info("메시지 큐에 전송 성공");
+            }
+        });
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsResponseDto.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsResponseDto.java
@@ -1,24 +1,31 @@
 package com.unicornstudy.singleshop.items.command.application.dto;
 
+import com.unicornstudy.singleshop.items.domain.ChildCategory;
 import com.unicornstudy.singleshop.items.domain.Items;
+import com.unicornstudy.singleshop.items.domain.ParentCategory;
+import com.unicornstudy.singleshop.items.query.domain.ItemsIndex;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class ItemsResponseDto {
 
-    private final Long id;
-    private final String name;
-    private final Integer price;
-    private final String description;
-    private final Integer quantity;
-    private final LocalDateTime createdDate;
-    private final LocalDateTime modifiedDate;
+    private Long id;
+    private String name;
+    private Integer price;
+    private String description;
+    private Integer quantity;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private String parentCategory;
+    private String childCategory;
 
     @Builder
-    public ItemsResponseDto(Long id, String name, Integer price, String description, Integer quantity, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+    public ItemsResponseDto(Long id, String name, Integer price, String description, Integer quantity, LocalDateTime createdDate, LocalDateTime modifiedDate, String parentCategory, String childCategory) {
         this.id = id;
         this.name = name;
         this.price = price;
@@ -26,6 +33,8 @@ public class ItemsResponseDto {
         this.quantity = quantity;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
+        this.parentCategory = parentCategory;
+        this.childCategory = childCategory;
     }
 
     public static ItemsResponseDto from(Items items) {
@@ -37,6 +46,23 @@ public class ItemsResponseDto {
                 .description(items.getDescription())
                 .createdDate(items.getCreatedDate())
                 .modifiedDate(items.getModifiedDate())
+                .parentCategory(items.getParentCategory().name())
+                .childCategory(items.getChildCategory().name())
+                .build();
+    }
+
+    public ItemsIndex toEntity() {
+
+        return ItemsIndex.builder()
+                .id(getId())
+                .name(getName())
+                .price(getPrice())
+                .description(getDescription())
+                .quantity(getQuantity())
+                .modifiedDate(getModifiedDate().toString())
+                .createdDate(getCreatedDate().toString())
+                .parentCategory(ParentCategory.valueOf(getParentCategory()))
+                .childCategory(ChildCategory.valueOf(getChildCategory()))
                 .build();
     }
 

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/messageQueue/kafka/ItemsEventListener.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/messageQueue/kafka/ItemsEventListener.java
@@ -1,0 +1,28 @@
+package com.unicornstudy.singleshop.items.command.application.messageQueue.kafka;
+
+import com.unicornstudy.singleshop.items.command.application.dto.ItemsResponseDto;
+import com.unicornstudy.singleshop.items.query.domain.repository.ItemsSearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ItemsEventListener {
+
+    private final ItemsSearchRepository itemsSearchRepository;
+
+    @KafkaListener(topics = "ItemsCreateAndUpdateTopic", groupId = "items")
+    public void createAndUpdateItemsIndex(ItemsResponseDto itemsResponseDto) {
+        log.info("ItemsCreateAndUpdateTopic 큐 메시지 도착");
+        itemsSearchRepository.save(itemsResponseDto.toEntity());
+    }
+
+    @KafkaListener(topics = "ItemsDeleteTopic", groupId = "items")
+    public void deleteItemsIndex(Long id) {
+        log.info("ItemsDeleteTopic 큐 메시지 도착");
+        itemsSearchRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/application/ItemsSearchService.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/application/ItemsSearchService.java
@@ -21,8 +21,8 @@ public class ItemsSearchService {
                 .toList();
     }
 
-    public List<ItemsSearchDto> findItems(String name, int price1, int price2, String parentCategory, String childCategory, Pageable pageable) {
-        return itemsSearchRepository.findItems(name, price1, price2, parentCategory, childCategory, pageable)
+    public List<ItemsSearchDto> searchItemsByNamePriceAndCategory(String name, int price1, int price2, String parentCategory, String childCategory, Pageable pageable) {
+        return itemsSearchRepository.searchItemsByNamePriceAndCategory(name, price1, price2, parentCategory, childCategory, pageable)
                 .stream()
                 .map(items -> ItemsSearchDto.from(items))
                 .toList();

--- a/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/ItemsSearchRepository.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/ItemsSearchRepository.java
@@ -14,5 +14,5 @@ public interface ItemsSearchRepository extends ElasticsearchRepository<ItemsInde
             "{\"range\": {\"price\": {\"gte\": ?1,\"lte\": ?2}}}," +
             "{\"wildcard\": {\"parentCategory\": \"*?3*\"}}," +
             "{\"wildcard\": {\"childCategory\": \"*?4*\"}}]}}")
-    List<ItemsIndex> findItems(String name, Integer price1, Integer price2, String parentCategory, String childCategory, Pageable pageable);
+    List<ItemsIndex> searchItemsByNamePriceAndCategory(String name, Integer price1, Integer price2, String parentCategory, String childCategory, Pageable pageable);
 }

--- a/src/main/java/com/unicornstudy/singleshop/items/query/presentation/ItemsSearchController.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/presentation/ItemsSearchController.java
@@ -20,14 +20,14 @@ public class ItemsSearchController {
     private final ItemsSearchService itemsSearchService;
 
     @GetMapping("/{name}")
-    public ResponseEntity<List<ItemsSearchDto>> findById(@PathVariable String name,
-                                                         @RequestParam(value = "price1", defaultValue = "0") int price1,
-                                                         @RequestParam(value= "price2", defaultValue = "2147483647") int price2,
+    public ResponseEntity<List<ItemsSearchDto>> searchItemsByNamePriceAndCategory(@PathVariable String name,
+                                                         @RequestParam(value = "minPrice", defaultValue = "0") int minPrice,
+                                                         @RequestParam(value= "maxPrice", defaultValue = "2147483647") int maxPrice,
                                                          @RequestParam(value = "parentCategory", defaultValue = "") String parentCategory,
                                                          @RequestParam(value = "childCategory", defaultValue = "") String childCategory,
                                                          @PageableDefault(size=10, sort="createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-        System.out.println(price1);
-        return new ResponseEntity<>(itemsSearchService.findItems(name, price1, price2, parentCategory, childCategory, pageable), HttpStatus.OK);
+
+        return new ResponseEntity<>(itemsSearchService.searchItemsByNamePriceAndCategory(name, minPrice, maxPrice, parentCategory, childCategory, pageable), HttpStatus.OK);
 
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,21 @@ spring:
     username: "${mySQLId}"
     password: "${mySQLPw}"
     url: jdbc:mysql://localhost:3307/unicorn?serverTimezone=UTC&characterEncoding=UTF-8
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        retries: 3
+        retry.backoff.ms: 1000
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
+      properties:
+        spring.json.trusted.packages: com.unicornstudy.singleshop.*
+
 cid: "${kakaoPayTestCid}"
 subscription-cid: "${kakaoPayTestSubscriptionCid}"
 approve-url: http://localhost:8080/api/payments/kakaopay/approve


### PR DESCRIPTION
common/config/kafka -> elasticsearch에서 저장 실패시 3회 시도한 후 DLT 메시지 큐에 메시지 넣도록 설정

AOP -> itemService의 save, update 작업이 성공하면 createAndUpdate 토픽으로 메시지 전송하도록 공통 기능 구현, delete 작업 수행시 delete 토픽으로 메시지 전송 이때 마찬가지로 메시지 전송 실패시 3회 시도 후 DLT 큐에 메시지 넣음

ItemsEventListener -> 각 토픽에 맞는 메시지를 알맞게 소비 하도록 구현
소비 방법: elasticsearch 저장소에 저장, 저장 실패 시 config 코드에 의해 DLT 메시지 큐에 메시지를 넣는다.
