### PR TITLE
refactor: Elasticsearch쿼리빌더 적용,itemsService.update로직변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 
 ## 사용 기술
-![적용기술](https://user-images.githubusercontent.com/79970349/236384005-105bbd1a-1caf-4bfc-8241-23bec87c06ca.png)
+![적용기술](https://github.com/unicornstudy/single-shop/assets/79970349/fe82e671-51e8-4f1b-ada5-dfe02e78d473)
 
 ## WIKI
 해당 프로젝트의 모든 정보는 [WIKI](https://github.com/unicornstudy/single-shop/wiki) 를 통해 참고하실 수 있습니다. 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	implementation group: 'org.springframework.batch', name: 'spring-batch-integration', version: '5.0.1'
     implementation 'org.projectlombok:lombok:1.18.20'
 	implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
-	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/unicornstudy/singleshop/common/infrastructure/elasticsearch/ElasticSearchService.java
+++ b/src/main/java/com/unicornstudy/singleshop/common/infrastructure/elasticsearch/ElasticSearchService.java
@@ -1,0 +1,60 @@
+package com.unicornstudy.singleshop.common.elasticsearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.springframework.data.domain.Pageable;
+import org.elasticsearch.search.SearchHits;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ElasticSearchService {
+
+    private final RestHighLevelClient client;
+    private final ObjectMapper objectMapper;
+
+    public <T> List<T> performSearch(BoolQueryBuilder queryBuilder, String indexName, Pageable pageable, Class<T> resultClass) {
+        SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(queryBuilder, pageable);
+        SearchRequest searchRequest = createSearchRequest(searchSourceBuilder, indexName);
+        SearchHits hits = createSearchHits(searchRequest);
+
+        return Arrays.stream(hits.getHits())
+                .map(hit -> objectMapper.convertValue(hit.getSourceAsMap(), resultClass))
+                .toList();
+    }
+
+    private SearchRequest createSearchRequest(SearchSourceBuilder searchSourceBuilder, String indexName) {
+        SearchRequest searchRequest = new SearchRequest(indexName);
+        searchRequest.source(searchSourceBuilder);
+
+        return searchRequest;
+    }
+
+    private SearchHits createSearchHits(SearchRequest searchRequest)  {
+        SearchHits hits = null;
+        try {
+            hits = client.search(searchRequest, RequestOptions.DEFAULT).getHits();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return hits;
+    }
+
+    private SearchSourceBuilder createSearchSourceBuilder(BoolQueryBuilder queryBuilder, Pageable pageable) {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(queryBuilder);
+        searchSourceBuilder.from((int) pageable.getOffset());
+        searchSourceBuilder.size(pageable.getPageSize());
+
+        return searchSourceBuilder;
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/common/infrastructure/elasticsearch/ElasticsearchConfig.java
+++ b/src/main/java/com/unicornstudy/singleshop/common/infrastructure/elasticsearch/ElasticsearchConfig.java
@@ -1,4 +1,4 @@
-package com.unicornstudy.singleshop.items.query.infrastructure;
+package com.unicornstudy.singleshop.common.infrastructure.elasticsearch;
 
 import com.unicornstudy.singleshop.items.query.domain.repository.ItemsSearchRepository;
 import org.elasticsearch.client.RestHighLevelClient;

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/ItemsService.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/ItemsService.java
@@ -28,7 +28,7 @@ public class ItemsService {
     public ItemsResponseDto findById(Long id) {
         Items items = itemsRepository.findById(id).orElseThrow(() -> new ItemsException(BAD_REQUEST_ITEMS_READ));
         return ItemsResponseDto.from(items);
-    }
+    }   
 
     @Transactional(readOnly = true)
     public List<ItemsResponseDto> findAll(Pageable pageable) {
@@ -46,10 +46,7 @@ public class ItemsService {
     @Transactional
     public ItemsResponseDto update(Long id, ItemsRequestDto requestDto) {
         Items items = itemsRepository.findById(id).orElseThrow(() -> new ItemsException(BAD_REQUEST_ITEMS_READ));
-
-        items.update(id, requestDto.getName(), requestDto.getPrice(),
-                requestDto.getDescription(), requestDto.getQuantity(),
-                ParentCategory.valueOf(requestDto.getParentCategory()), ChildCategory.valueOf(requestDto.getChildCategory()));
+        requestDto.updateItems(items);
         return ItemsResponseDto.from(items);
     }
 

--- a/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsRequestDto.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/command/application/dto/ItemsRequestDto.java
@@ -33,4 +33,7 @@ public class ItemsRequestDto {
                 .build();
     }
 
+    public void updateItems(Items items) {
+        items.update(getName(), getPrice(), getDescription(), getQuantity(), ParentCategory.valueOf(getParentCategory()), ChildCategory.valueOf(getChildCategory()));
+    }
 }

--- a/src/main/java/com/unicornstudy/singleshop/items/domain/Items.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/domain/Items.java
@@ -42,8 +42,7 @@ public class Items {
     @Enumerated(EnumType.STRING)
     private ChildCategory childCategory;
 
-    public void update(Long id, String name, Integer price, String description, Integer quantity, ParentCategory parentCategory, ChildCategory childCategory) {
-        this.id = id;
+    public void update(String name, Integer price, String description, Integer quantity, ParentCategory parentCategory, ChildCategory childCategory) {
         this.name = name;
         this.price = price;
         this.description = description;

--- a/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/CustomItemsSearchRepository.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/CustomItemsSearchRepository.java
@@ -1,0 +1,10 @@
+package com.unicornstudy.singleshop.items.query.domain.repository;
+
+import com.unicornstudy.singleshop.items.query.domain.ItemsIndex;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CustomItemsSearchRepository {
+    List<ItemsIndex> findItems(String name, Integer price1, Integer price2, String parentCategory, String childCategory, Pageable pageable);
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/CustomItemsSearchRepositoryImpl.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/CustomItemsSearchRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.unicornstudy.singleshop.items.query.domain.repository;
+
+import com.unicornstudy.singleshop.common.elasticsearch.ElasticSearchService;
+import com.unicornstudy.singleshop.items.query.domain.ItemsIndex;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomItemsSearchRepositoryImpl implements CustomItemsSearchRepository {
+
+    private final ElasticSearchService elasticSearchService;
+
+    @Override
+    public List<ItemsIndex> findItems(String name, Integer price1, Integer price2, String parentCategory, String childCategory, Pageable pageable) {
+        BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery()
+                .must(
+                        QueryBuilders.boolQuery()
+                                .should(QueryBuilders.wildcardQuery("name", "*" + name + "*"))
+                                .should(QueryBuilders.wildcardQuery("description", "*" + name + "*"))
+                )
+                .must(QueryBuilders.rangeQuery("price").gte(price1).lte(price2))
+                .must(QueryBuilders.wildcardQuery("parentCategory", "*" + parentCategory + "*"))
+                .must(QueryBuilders.wildcardQuery("childCategory", "*" + childCategory + "*"));
+
+        return elasticSearchService.performSearch(queryBuilder, "items", pageable, ItemsIndex.class);
+    }
+}

--- a/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/ItemsSearchRepository.java
+++ b/src/main/java/com/unicornstudy/singleshop/items/query/domain/repository/ItemsSearchRepository.java
@@ -8,11 +8,5 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 
-public interface ItemsSearchRepository extends ElasticsearchRepository<ItemsIndex, Long>, CrudRepository<ItemsIndex, Long> {
-
-    @Query("{\"bool\": {\"must\": [{\"bool\": {\"should\": [{\"wildcard\": {\"name\":\"*?0*\"}},{\"wildcard\": {\"description\": \"*?0*\"}}]}}," +
-            "{\"range\": {\"price\": {\"gte\": ?1,\"lte\": ?2}}}," +
-            "{\"wildcard\": {\"parentCategory\": \"*?3*\"}}," +
-            "{\"wildcard\": {\"childCategory\": \"*?4*\"}}]}}")
-    List<ItemsIndex> searchItemsByNamePriceAndCategory(String name, Integer price1, Integer price2, String parentCategory, String childCategory, Pageable pageable);
+public interface ItemsSearchRepository extends ElasticsearchRepository<ItemsIndex, Long>, CrudRepository<ItemsIndex, Long>, CustomItemsSearchRepository {
 }

--- a/src/test/java/com/unicornstudy/singleshop/items/ItemsRepositoryTest.java
+++ b/src/test/java/com/unicornstudy/singleshop/items/ItemsRepositoryTest.java
@@ -131,7 +131,7 @@ class ItemsRepositoryTest {
         ChildCategory childCategory = ChildCategory.KIMCHI;
 
 
-        items.update(items.getId(), updateName, updatePrice, updateDescription, updateQuantity, parentCategory, childCategory);
+        items.update(updateName, updatePrice, updateDescription, updateQuantity, parentCategory, childCategory);
 
         assertThat(items.getName()).isEqualTo(updateName);
         assertThat(items.getPrice()).isEqualTo(updatePrice);


### PR DESCRIPTION
Elasticsearch 복잡한 쿼리 -> 쿼리빌더 적용

itemsService.update 메소드 -> 인자가 많기 때문에 Dto에 책임 위임하고 캡슐화